### PR TITLE
handle events that are not supported

### DIFF
--- a/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
+++ b/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
@@ -115,6 +115,11 @@ function processEvent(event, callback) {
     
     var path = process.env.API_URL;
 
+    if (!('repository' in body) || !('ref' in body)) {
+        console.log('Event is not supported')
+        callback(null, {"statusCode": 200, "body": "Currently, this lambda does not support this event type from GitHub."});
+    }
+
     // A push has been made for some repository (ignore pushes that are deletes)
     if (!body.deleted) {
         console.log('Valid push event');

--- a/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
+++ b/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
@@ -121,7 +121,7 @@ function processEvent(event, callback) {
      * 
      * If an event is deemed not supported, we will return a success and print a message saying the event is not supported.
      */
-    if (!('repository' in body) || !('ref' in body) || !('created' in body) || !('deleted' in body) || !('pusher' in body)) {
+    if (!('repository' in body && 'ref' in body && 'created' in body && 'deleted' in body && 'pusher' in body)) {
         console.log('Event is not supported')
         callback(null, {"statusCode": 200, "body": "Currently, this lambda does not support this event type from GitHub."});
     }

--- a/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
+++ b/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
@@ -121,7 +121,7 @@ function processEvent(event, callback) {
      * 
      * If an event is deemed not supported, we will return a success and print a message saying the event is not supported.
      */
-    if (!('repository' in body && 'ref' in body && 'created' in body && 'deleted' in body && 'pusher' in body)) {
+    if (['repository', 'ref', 'created', 'deleted', 'pusher'].some(str => !(str in body))) {
         console.log('Event is not supported')
         callback(null, {"statusCode": 200, "body": "Currently, this lambda does not support this event type from GitHub."});
     }

--- a/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
+++ b/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
@@ -115,7 +115,13 @@ function processEvent(event, callback) {
     
     var path = process.env.API_URL;
 
-    if (!('repository' in body) || !('ref' in body)) {
+    /**
+     * We only handle push events, of which there are many subtypes. Unfortunately, the only way to differentiate between them is to look
+     * for expected fields. There are no enums for push events subtypes.
+     * 
+     * If an event is deemed not supported, we will return a success and print a message saying the event is not supported.
+     */
+    if (!('repository' in body) || !('ref' in body) || !('created' in body) || !('deleted' in body) || !('pusher' in body)) {
         console.log('Event is not supported')
         callback(null, {"statusCode": 200, "body": "Currently, this lambda does not support this event type from GitHub."});
     }


### PR DESCRIPTION
Seems like there were some events that were getting through causing errors that we don't care about (ex. repository installs). Now we check for specific fields, and if any are missing we return success (so that lambda doesn't retry) and print a message saying unsupported.