### PR TITLE
Fix/encoding

### DIFF
--- a/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
+++ b/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
@@ -17,7 +17,7 @@ const verifyGitHub = (req) => {
   
   // Need to decode base64 encoded payload
   var buff = Buffer.from(req.payload, 'base64');
-  const payload = buff.toString('utf-8');
+  const payload = buff.toString('utf8');
   const secret = process.env.SECRET_TOKEN; 
   const ourSignature = `sha1=${crypto.createHmac('sha1', secret).update(payload).digest('hex')}`;
   return crypto.timingSafeEqual(Buffer.from(theirSignature), Buffer.from(ourSignature));
@@ -112,7 +112,7 @@ function processEvent(event, callback) {
     
     // The payload is encoded in base64
     const buff = Buffer.from(requestBody.payload, 'base64');
-    const body = JSON.parse(buff.toString('utf-8'));
+    const body = JSON.parse(buff.toString('utf8'));
 
     console.log('GitHub Payload');
     console.log(JSON.stringify(body));

--- a/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
+++ b/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
@@ -48,7 +48,7 @@ function postEndpoint(path, postBody, callback) {
            if (callback) {
                // If content-type is text/plain, the body contains the message, else the message is found in the JSON object
                var contentType = res.headers['content-type'];
-               var responseMessage = contentType && contentType.includes('text/plain') ? bodyString : res.statusMessage;
+               var responseMessage = contentType.includes('text/plain') ? bodyString : res.statusMessage;
                callback({
                    statusCode: res.statusCode,
                    statusMessage: responseMessage

--- a/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
+++ b/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
@@ -17,7 +17,7 @@ const verifyGitHub = (req) => {
   
   // Need to decode base64 encoded payload
   var buff = new Buffer(req.payload, 'base64');
-  const payload = buff.toString('ascii');
+  const payload = buff.toString('utf-8');
   const secret = process.env.SECRET_TOKEN; 
   const ourSignature = `sha1=${crypto.createHmac('sha1', secret).update(payload).digest('hex')}`;
   return crypto.timingSafeEqual(Buffer.from(theirSignature), Buffer.from(ourSignature));
@@ -112,7 +112,7 @@ function processEvent(event, callback) {
     
     // The payload is encoded in base64
     const buff = Buffer.from(requestBody.payload, 'base64');
-    const body = JSON.parse(buff.toString('ascii'));
+    const body = JSON.parse(buff.toString('utf-8'));
 
     console.log('GitHub Payload');
     console.log(JSON.stringify(body));

--- a/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
+++ b/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
@@ -16,7 +16,7 @@ const verifyGitHub = (req) => {
   const theirSignature = req['X-Hub-Signature'];
   
   // Need to decode base64 encoded payload
-  var buff = new Buffer(req.payload, 'base64');
+  var buff = Buffer.from(req.payload, 'base64');
   const payload = buff.toString('utf-8');
   const secret = process.env.SECRET_TOKEN; 
   const ourSignature = `sha1=${crypto.createHmac('sha1', secret).update(payload).digest('hex')}`;


### PR DESCRIPTION
Fixes some of the "GitHub could not be verified" issues for example the request with "sha1=3bf87d669ea8f1b9e197038cd54fb1208de3f9ed" 

does not appear to fix the "sha1=94f66b91339bb2719ba6cc8ce0269f69003923a2" one

tested locally. could probably make a test but kind of troublesome with the secret

Other PR https://github.com/dockstore/lambda/pull/20 seems to have an issue. Decode was not necessary.