### PR TITLE
change console.error to console.info to avoid AWS Lambda Errors

### DIFF
--- a/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
+++ b/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
@@ -202,7 +202,7 @@ function handleCallback(response, successMessage, callback) {
         callback(null);
     } else if (response.statusCode < 500) {
         // Client error, don't retry
-        console.error(`Error handling GitHub webhook, will not retry: ${response.statusCode} - ${response.statusMessage}`);
+        console.info(`Error handling GitHub webhook, will not retry: ${response.statusCode} - ${response.statusMessage}`);
         callback(null);
     } else {
         // Server error, retry


### PR DESCRIPTION
Main issue: https://ucsc-cgl.atlassian.net/browse/SEAB-1692

Sibling PR: https://github.com/dockstore/dockstore-deploy/pull/118

I'm hoping to leverage Lambda's built-in `Errors` metric to set up alarms for our GitHub Apps Lambda. But we don't want 4XX responses like 418 to show as errors (since they are easily caused by tags/branches without `.dockstore.yml`).

Changing this to an `INFO` log makes the `Errors` metric perfect for our intended use.

More info in these comments: https://ucsc-cgl.atlassian.net/browse/SEAB-1692?focusedCommentId=31853