### PR TITLE
Code for dev, staging and prod AWS SSM and AWS config lambda

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,6 +17,10 @@ jobs:
        working-directory: ./upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7
      - run: npx eslint deployment/index.js
        working-directory: ./upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7
+     - run: npm install
+       working-directory: ./cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8
+     - run: npx eslint deployment/index.js
+       working-directory: ./cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8
   testWithSAMCLI:
      runs-on: ubuntu-latest
      steps:

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -60,22 +60,8 @@ function processEvent(event, callback) {
     const message = JSON.parse(event.Records[0].Sns.Message);
 
     let messageText;
-    var attachments = null;
 
-    if (message.hasOwnProperty('mail')) {
-        const source = message.mail.commonHeaders.from.join();
-        const destination = message.mail.destination.join();
-        const subject = message.mail.commonHeaders.subject;
-        console.log(message.content);
-        messageText = `email from ${source} to ${destination} with subject of ${subject}`;
-        attachments = [
-            {
-             fallback: 'foo',
-             title: 'email content',
-             text: message.content
-            }
-        ];
-    } else if (message.source == 'aws.config') {
+    if (message.source == 'aws.config') {
         const alarmName = message.detail.configRuleName;
         const newState = message.detail.newEvaluationResult.complianceType;
         messageText = `${alarmName} state is now ${newState}`;
@@ -103,10 +89,6 @@ function processEvent(event, callback) {
         text: messageText,
     };
 
-    if (attachments !== null) {
-        slackMessage.attachments = attachments;
-    }
-
     postMessage(slackMessage, (response) => {
         if (response.statusCode < 400) {
             console.info('Message posted successfully on Slack');
@@ -123,8 +105,8 @@ function processEvent(event, callback) {
 
 
 exports.handler = (event, context, callback) => {
-    // Uncomment the folling line to see the event in the CloudWatch logs
-    //console.info("cloud-watch-to-slack-testing EVENT\n" + JSON.stringify(event, null, 2));
+    // This will record the event in the CloudWatch logs
+    console.info("cloud-watch-to-slack-testing EVENT\n" + JSON.stringify(event, null, 2));
     if (hookUrl) {
         processEvent(event, callback);
     } else {

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -155,7 +155,7 @@ function processEvent(event, callback) {
         if (message.detail.hasOwnProperty("requestParameters") && message.detail['requestParameters']) {
           if (message.detail.requestParameters.hasOwnProperty("target")) {
             const targetInstance = message.detail.requestParameters.target;
-            getInstanceNameAndSendMsgToSlack(targetInstance, messageText, callback, constructMsgAndSendToSlack);\
+            getInstanceNameAndSendMsgToSlack(targetInstance, messageText, callback, constructMsgAndSendToSlack);
             //messageText = messageText + ` to target: ${targetInstanceName} (${targetInstance})`;
           }
         } else {

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -21,8 +21,6 @@ const url = require('url');
 const https = require('https');
 var AWS = require("aws-sdk");
 
-var targetInstanceName = 'unknown';
-
 // The Slack URL to send the message to
 const hookUrl = process.env.hookUrl;
 // The Slack channel to send a message to stored in the slackChannel environment variable

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -70,13 +70,21 @@ function processEvent(event, callback) {
         const userName = message.detail.userIdentity.userName;
         const sourceIPAddress = message.detail.sourceIPAddress;
         messageText = `${userName} initiated AWS Systems Manager (SSM) event ${eventName} from IP ${sourceIPAddress}`;
-        if (message.detail.hasOwnProperty("requestParameters")) {
+        if (message.detail.hasOwnProperty("requestParameters") && message.detail['requestParameters']) {
           if (message.detail.requestParameters.hasOwnProperty("target")) {
             const targetInstance = message.detail.requestParameters.target;
             messageText = messageText + ` to target: ${targetInstance}`;
           }
-       }
-       messageText = messageText + ` in region: ` + message.region;
+        }
+        if (message.detail.hasOwnProperty("errorCode") && message.detail['errorCode']) {
+          const errorCode = message.detail.errorCode;
+          messageText = messageText + ` but received error code ` + ${errorCode};
+        }
+        if (message.detail.hasOwnProperty("errorMessage") && message.detail['errorMessage']) {
+          const errorMessage = message.detail.errorMessage;
+          messageText = messageText + ` with error message ` + ${errorMessage};
+        }
+        messageText = messageText + ` in region: ` + message.region;
     } else {
         const alarmName = message.AlarmName;
         const newState = message.NewStateValue;

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -50,16 +50,14 @@ function getInstanceName(myInstanceId, callback) {
           for (var k = 0; k < tags.length; k++) {
             if (tags[k].Key == 'Name') {
               instanceName = tags[k].Value;
-              callback(instanceName);
-              return;
+              return callback(instanceName);
             }
           }
-          callback(instancename);
-          return;
+          return callback(instancename);
         }
       }
     }
-    callback(instanceName)
+    return callback(instanceName)
  });
 }
 

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -68,7 +68,7 @@ function getInstanceName(myInstanceId, callback) {
  return callback(instanceName);
 }
 
-function foundInstanceName(instanceName) {i
+function foundInstanceName(instanceName) {
   console.info(`Found instance name:${instanceName}` );
   return instanceName;
 }

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -33,9 +33,7 @@ const dockstoreEnvironment = process.env.dockstoreEnvironment;
 // and find the one with the instance ID in question.
 // Then go through all the tags on that instance and
 // find the one with the key 'Name', whose value
-// is the name displayed on the console of the instance,
-// and return that name.
-
+// is the name displayed on the console of the instance.
 function getInstanceNameAndSendMsgToSlack(targetInstanceId, messageText, processEventCallback, callback) {
 //function getInstanceName(myInstanceId, callback) {
   var ec2 = new AWS.EC2();
@@ -74,7 +72,6 @@ function constructMsgAndSendToSlack(messageText, targetInstanceName, targetInsta
   messageText = messageText + ` to target: ${targetInstanceName} (${targetInstanceId})`;
 
   sendMessageToSlack(messageText, callback)
-  //return targetInstanceName;
 }
 
 function postMessage(message, callback) {
@@ -136,7 +133,7 @@ function processEvent(event, callback) {
         const alarmName = message.detail.configRuleName;
         const newState = message.detail.newEvaluationResult.complianceType;
         messageText = `${alarmName} state is now ${newState}`;
-        sendMessageToSlack(message, callback)
+        sendMessageToSlack(messageText, callback)
     } else if (message.source == 'aws.ssm') {
         const eventName = message.detail.eventName;
         const userName = message.detail.userIdentity.userName;
@@ -147,55 +144,25 @@ function processEvent(event, callback) {
           const errorCode = message.detail.errorCode;
           messageText = messageText + ` but received error code: ${errorCode}`;
         }
-        messageText = messageText + ` on Dockstore ` + dockstoreEnvironment + ` in region: ` + message.region;
 
-        messageText = messageText + `Event was initiated from IP ${sourceIPAddress}`;
+        messageText = messageText + ` on Dockstore ` + dockstoreEnvironment + ` in region: ` + message.region + `.`;
+        messageText = messageText + ` Event was initiated from IP ${sourceIPAddress}`;
 
         if (message.detail.hasOwnProperty("requestParameters") && message.detail['requestParameters']) {
           if (message.detail.requestParameters.hasOwnProperty("target")) {
             const targetInstanceId = message.detail.requestParameters.target;
             getInstanceNameAndSendMsgToSlack(targetInstanceId, messageText, callback, constructMsgAndSendToSlack);
-            //messageText = messageText + ` to target: ${targetInstanceName} (${targetInstance})`;
           }
         } else {
-          sendMessageToSlack(message, callback);
+          sendMessageToSlack(messageText, callback);
         }
-
-        //if (message.detail.hasOwnProperty("errorCode") && message.detail['errorCode']) {
-        //  const errorCode = message.detail.errorCode;
-        //  messageText = messageText + ` but received error code: ${errorCode}`;
-        //}
-
-        //if (message.detail.hasOwnProperty("errorMessage") && message.detail['errorMessage']) {
-        //  const errorMessage = message.detail.errorMessage;
-        //  messageText = messageText + ` with error message: ${errorMessage}`;
-        //}
-        //messageText = messageText + ` on Dockstore ` + dockstoreEnvironment + ` in region: ` + message.region;
     } else {
         const alarmName = message.AlarmName;
         const newState = message.NewStateValue;
         const reason = message.NewStateReason;
         messageText = `${alarmName} state is now ${newState}: ${reason}`;
-        sendMessageToSlack(message, callback);
+        sendMessageToSlack(messageText, callback);
     }
-
-    //const slackMessage = {
-    //    channel: slackChannel,
-    //    text: messageText,
-    //};
-
-    //postMessage(slackMessage, (response) => {
-    //    if (response.statusCode < 400) {
-    //        console.info('Message posted successfully on Slack');
-    //        callback(null);
-    //    } else if (response.statusCode < 500) {
-    //        console.error(`Error posting message to Slack API: ${response.statusCode} - ${response.statusMessage}`);
-    //        callback(null);  // Don't retry because the error is due to a problem with the request
-    //    } else {
-    //        // Let Lambda retry
-    //        callback(`Server error when processing message: ${response.statusCode} - ${response.statusMessage}`);
-    //    }
-    //});
 }
 
 

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -36,15 +36,14 @@ function getInstanceNameAndSendMsgToSlack(targetInstanceId, messageText, process
   const ec2 = new AWS.EC2();
 
   ec2.describeInstances(function(err, result) {
-    if (err) {
+    if (err)
       console.log(err); // Log the error message.
-      // Send the error message to Slack
-      return callback(err, tagInstanceName, targetInstanceId, processEventCallback);
-    } else {
+    else {
       for (var i = 0; i < result.Reservations.length; i++) {
         var res = result.Reservations[i];
         var instances = res.Instances;
 
+        // Try to get the user friendly name of the EC2 target instance
         var instance = instances.find(instance => instance.InstanceId === targetInstanceId);
         var tagInstanceNameKey = (instance && instance.Tags.find(tag => 'Name' === tag.Key));
         if (tagInstanceNameKey) {
@@ -53,6 +52,9 @@ function getInstanceNameAndSendMsgToSlack(targetInstanceId, messageText, process
         }
       }
     }
+    // If there was an error or the user friendly name was not found just send the
+    // message to Slack with a default name for the target
+    return callback(messageText, 'unknown', targetInstanceId, processEventCallback);
   });
 }
 

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -46,8 +46,11 @@ function getInstanceNameAndSendMsgToSlack(targetInstanceId, messageText, process
         var instances = res.Instances;
 
         var instance = instances.find(instance => instance.InstanceId === targetInstanceId);
+        console.info(`Found instance ID:${instance}`);
         var tagInstanceNameKey = (instance && instance.Tags.find(tag => 'Name' === tag.Key));
+        console.info(`Found tag key:${tagInstanceNameKey}`);
         var tagInstanceName = (tagInstanceNameKey && tagInstanceNameKey.Value) || 'unknown';
+        console.info(`Found tag key value:${tagInstanceNameKey.Value}`);
         if (tagInstanceNameKey)
           return callback(messageText, tagInstanceName, targetInstanceId, processEventCallback);
       }
@@ -165,6 +168,7 @@ function processEvent(event, callback) {
           if (Object.prototype.hasOwnProperty.call(message.detail, "target")) {
           //if (message.detail.requestParameters.hasOwnProperty("target")) {
             const targetInstanceId = message.detail.requestParameters.target;
+            console.info(`Found target instance ID:${targetInstanceId}`);
             getInstanceNameAndSendMsgToSlack(targetInstanceId, messageText, callback, constructMsgAndSendToSlack);
           }
         } else {

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -165,7 +165,7 @@ function processEvent(event, callback) {
 
         if (Object.prototype.hasOwnProperty.call(message.detail, "requestParameters") && message.detail['requestParameters']) {
         //if (message.detail.hasOwnProperty("requestParameters") && message.detail['requestParameters']) {
-          if (Object.prototype.hasOwnProperty.call(message.detail, "target")) {
+          if (Object.prototype.hasOwnProperty.call(message.detail.requestParameters, "target")) {
           //if (message.detail.requestParameters.hasOwnProperty("target")) {
             const targetInstanceId = message.detail.requestParameters.target;
             console.info(`Found target instance ID:${targetInstanceId}`);

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -50,10 +50,10 @@ function getInstanceNameAndSendMsgToSlack(targetInstanceId, messageText, process
         var tagInstanceNameKey = (instance && instance.Tags.find(tag => 'Name' === tag.Key));
         console.info(`Found tag key:${tagInstanceNameKey}`);
         var tagInstanceName = (tagInstanceNameKey && tagInstanceNameKey.Value) || 'unknown';
-        if (tagInstanceNameKey)
+        if (tagInstanceNameKey) {
           console.info(`Found tag key value:${tagInstanceNameKey.Value}`);
-        if (tagInstanceNameKey)
           return callback(messageText, tagInstanceName, targetInstanceId, processEventCallback);
+        }
       }
     }
 

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -41,7 +41,7 @@ function getInstanceNameAndSendMsgToSlack(targetInstance, messageText, processEv
   var ec2 = new AWS.EC2();
   var tagInstanceName = 'unknown';
 
-  console.info(`My instance ID:${myInstanceId}`);
+  console.info(`My instance ID:${targetInstance}`);
   ec2.describeInstances(function(err, result) {
     if (err)
       console.log(err); // Logs error message.

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -36,11 +36,11 @@ function getInstanceNameAndSendMsgToSlack(targetInstanceId, messageText, process
   const ec2 = new AWS.EC2();
 
   ec2.describeInstances(function(err, result) {
-    if (err)
+    if (err) {
       console.log(err); // Log the error message.
       // Send the error message to Slack
       return callback(err, tagInstanceName, targetInstanceId, processEventCallback);
-    else {
+    } else {
       for (var i = 0; i < result.Reservations.length; i++) {
         var res = result.Reservations[i];
         var instances = res.Instances;

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -78,11 +78,11 @@ function processEvent(event, callback) {
         }
         if (message.detail.hasOwnProperty("errorCode") && message.detail['errorCode']) {
           const errorCode = message.detail.errorCode;
-          messageText = messageText + ` but received error code ` + ${errorCode};
+          messageText = messageText + ` but received error code: ${errorCode}`;
         }
         if (message.detail.hasOwnProperty("errorMessage") && message.detail['errorMessage']) {
           const errorMessage = message.detail.errorMessage;
-          messageText = messageText + ` with error message ` + ${errorMessage};
+          messageText = messageText + ` with error message: ${errorMessage}`;
         }
         messageText = messageText + ` in region: ` + message.region;
     } else {

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -139,7 +139,7 @@ function processEvent(event, callback) {
         messageText = messageText + ` on Dockstore ` + dockstoreEnvironment + ` in region: ` + message.region + `.`;
         messageText = messageText + ` Event was initiated from IP ${sourceIPAddress}`;
 
-        if (Object.prototype.hasOwnProperty.call(message.detail, "requestParameters")
+        if (Object.prototype.hasOwnProperty.call(message.detail, "requestParameters") && message.detail['requestParameters']
             && Object.prototype.hasOwnProperty.call(message.detail.requestParameters, "target")) {
             const targetInstanceId = message.detail.requestParameters.target;
             getInstanceNameAndSendMsgToSlack(targetInstanceId, messageText, callback, constructMsgAndSendToSlack);

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -53,6 +53,7 @@ function getInstanceName(myInstanceId, callback) {
             console.info(`Found tag key:` + tags[k].Key);
             if (tags[k].Key == 'Name') {
               instanceName = tags[k].Value;
+              console.info(`Found target tag key:${instanceName}` );
               //return callback(instanceName);
               return;
             }
@@ -67,7 +68,8 @@ function getInstanceName(myInstanceId, callback) {
  return callback(instanceName);
 }
 
-function foundInstanceName(instanceName) {
+function foundInstanceName(instanceName) {i
+  console.info(`Found instance name:${instanceName}` );
   return instanceName;
 }
 

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -34,9 +34,7 @@ const dockstoreEnvironment = process.env.dockstoreEnvironment;
 // is the name displayed on the console of the instance.
 function getInstanceNameAndSendMsgToSlack(targetInstanceId, messageText, processEventCallback, callback) {
   const ec2 = new AWS.EC2();
-  //var tagInstanceName = 'unknown';
 
-  console.info(`My instance ID:${targetInstanceId}`);
   ec2.describeInstances(function(err, result) {
     if (err)
       console.log(err); // Logs error message.
@@ -46,39 +44,13 @@ function getInstanceNameAndSendMsgToSlack(targetInstanceId, messageText, process
         var instances = res.Instances;
 
         var instance = instances.find(instance => instance.InstanceId === targetInstanceId);
-        console.info(`Found instance ID:${instance}`);
         var tagInstanceNameKey = (instance && instance.Tags.find(tag => 'Name' === tag.Key));
-        console.info(`Found tag key:${tagInstanceNameKey}`);
         var tagInstanceName = (tagInstanceNameKey && tagInstanceNameKey.Value) || 'unknown';
         if (tagInstanceNameKey) {
-          console.info(`Found tag key value:${tagInstanceNameKey.Value}`);
           return callback(messageText, tagInstanceName, targetInstanceId, processEventCallback);
         }
       }
     }
-
-
-    //for (var i = 0; i < result.Reservations.length; i++) {
-    //  var res = result.Reservations[i];
-    //  var instances = res.Instances;
-    //  for (var j = 0; j < instances.length; j++) {
-    //    var instanceID = instances[j].InstanceId;
-    //    console.info(`Found instance ID:${targetInstanceId}`);
-    //    if ( instanceID === targetInstanceId ) {
-    //      var tags = instances[j].Tags;
-    //      for (var k = 0; k < tags.length; k++) {
-    //        console.info(`Found tag key:` + tags[k].Key);
-    //        if (tags[k].Key == 'Name') {
-    //          tagInstanceName = tags[k].Value;
-    //          console.info(`Found target tag key:${tagInstanceName}`);
-    //          return callback(messageText, tagInstanceName, targetInstanceId, processEventCallback );
-    //        }
-    //      }
-    //      return callback(messageText, tagInstanceName, targetInstanceId, processEventCallback);
-    //    }
-    //  }
-    //}
-    //return callback(messageText, tagInstanceName, targetInstanceId, processEventCallback)
   });
 }
 
@@ -156,7 +128,6 @@ function processEvent(event, callback) {
         messageText = `${userName} initiated AWS Systems Manager (SSM) event ${eventName}`;
 
         if (Object.prototype.hasOwnProperty.call(message.detail, "errorCode") && message.detail['errorCode']) {
-        //if (message.detail.hasOwnProperty("errorCode") && message.detail['errorCode']) {
           const errorCode = message.detail.errorCode;
           messageText = messageText + ` but received error code: ${errorCode}`;
         }
@@ -165,11 +136,8 @@ function processEvent(event, callback) {
         messageText = messageText + ` Event was initiated from IP ${sourceIPAddress}`;
 
         if (Object.prototype.hasOwnProperty.call(message.detail, "requestParameters") && message.detail['requestParameters']) {
-        //if (message.detail.hasOwnProperty("requestParameters") && message.detail['requestParameters']) {
           if (Object.prototype.hasOwnProperty.call(message.detail.requestParameters, "target")) {
-          //if (message.detail.requestParameters.hasOwnProperty("target")) {
             const targetInstanceId = message.detail.requestParameters.target;
-            console.info(`Found target instance ID:${targetInstanceId}`);
             getInstanceNameAndSendMsgToSlack(targetInstanceId, messageText, callback, constructMsgAndSendToSlack);
           }
         } else {

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -37,7 +37,7 @@ function getInstanceName(myInstanceId, callback) {
   var ec2 = new AWS.EC2();
   var instanceName = 'unknown';
 
-  console.info('My instance ID:${myInstanceId}');
+  console.info(`My instance ID:${myInstanceId}`);
   ec2.describeInstances(function(err, result) {
     if (err)
       console.log(err); // Logs error message.
@@ -46,11 +46,11 @@ function getInstanceName(myInstanceId, callback) {
       var instances = res.Instances;
       for (var j = 0; j < instances.length; j++) {
         var instanceID = instances[j].InstanceId;
-        console.info('Found instance ID:${instanceID}');
+        console.info(`Found instance ID:${instanceID}`);
         if ( instanceID === myInstanceId ) {
           var tags = instances[j].Tags;
           for (var k = 0; k < tags.length; k++) {
-            console.info('Found tag key:' + tags[k].Key);
+            console.info(`Found tag key:` + tags[k].Key);
             if (tags[k].Key == 'Name') {
               instanceName = tags[k].Value;
               //return callback(instanceName);

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -50,7 +50,8 @@ function getInstanceNameAndSendMsgToSlack(targetInstanceId, messageText, process
         var tagInstanceNameKey = (instance && instance.Tags.find(tag => 'Name' === tag.Key));
         console.info(`Found tag key:${tagInstanceNameKey}`);
         var tagInstanceName = (tagInstanceNameKey && tagInstanceNameKey.Value) || 'unknown';
-        console.info(`Found tag key value:${tagInstanceNameKey.Value}`);
+        if (tagInstanceNameKey)
+          console.info(`Found tag key value:${tagInstanceNameKey.Value}`);
         if (tagInstanceNameKey)
           return callback(messageText, tagInstanceName, targetInstanceId, processEventCallback);
       }

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -37,6 +37,7 @@ function getInstanceName(myInstanceId, callback) {
   var ec2 = new AWS.EC2();
   var instanceName = 'unknown';
 
+  console.info('My instance ID:${myInstanceId}');
   ec2.describeInstances(function(err, result) {
     if (err)
       console.log(err); // Logs error message.
@@ -45,9 +46,11 @@ function getInstanceName(myInstanceId, callback) {
       var instances = res.Instances;
       for (var j = 0; j < instances.length; j++) {
         var instanceID = instances[j].InstanceId;
+        console.info('Found instance ID:${instanceID}');
         if ( instanceID === myInstanceId ) {
           var tags = instances[j].Tags;
           for (var k = 0; k < tags.length; k++) {
+            console.info('Found tag key:' + tags[k].Key);
             if (tags[k].Key == 'Name') {
               instanceName = tags[k].Value;
               //return callback(instanceName);

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -50,15 +50,18 @@ function getInstanceName(myInstanceId, callback) {
           for (var k = 0; k < tags.length; k++) {
             if (tags[k].Key == 'Name') {
               instanceName = tags[k].Value;
-              return callback(instanceName);
+              //return callback(instanceName);
+              return;
             }
           }
-          return callback(instancename);
+          //return callback(instancename);
+          return;
         }
       }
     }
-    return callback(instanceName)
+    //return callback(instanceName)
  });
+ return callback(instanceName);
 }
 
 function foundInstanceName(instanceName) {

--- a/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
+++ b/cloud-watch-to-slack-testing-58006136-c30b-43d1-880c-7b36f860e7c8/deployment/index.js
@@ -17,7 +17,6 @@
  *
  */
 
-const AWS = require('aws-sdk');
 const url = require('url');
 const https = require('https');
 


### PR DESCRIPTION
This PR introduces code to send messages to Slack for dev, staging and prod. The lambda is different from what is currently on dev.dockstore.net in that this staging code uses AWS managed keys to encrypt the environment variables at rest instead of using a customer managed key. This simplifies the code. It's unclear to me why we need to use a customer managed key.

Strangely, the lambda currently on dev.dockstore.net handles mail attachments; but that is not reflected in the lambda code checked in here for develop. It's not clear to me if this code is needed.

Additionally, there are output-template.yml, template.yml files that do not match this new index.js code with respect to the AWS managed key use. It's unclear to me how these are generated.

This code is enabled with the CloudFormation template from PR https://github.com/dockstore/dockstore-deploy/pull/174.

