### PR TITLE
Added user-agent headers

### DIFF
--- a/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
+++ b/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
@@ -4,6 +4,7 @@ const url = require("url");
 const https = require("https");
 const crypto = require("crypto");
 const qs = require("querystring");
+const LAMBDA_USER_AGENT = "DockstoreLambda (NodeJs)";
 
 // Verification function to check if it is actually GitHub who is POSTing here
 const verifyGitHub = (req, payload) => {
@@ -34,7 +35,7 @@ function postEndpoint(path, postBody, callback) {
   options.headers = {
     "Content-Type": "application/x-www-form-urlencoded",
     Authorization: "Bearer " + process.env.DOCKSTORE_TOKEN,
-    "User-Agent": "NodeJs Dockstore Lambda",
+    "User-Agent": LAMBDA_USER_AGENT,
   };
 
   const req = https.request(options, (res) => {
@@ -87,7 +88,7 @@ function deleteEndpoint(
   options.method = "DELETE";
   options.headers = {
     Authorization: "Bearer " + process.env.DOCKSTORE_TOKEN,
-    "User-Agent": "NodeJs Dockstore Lambda",
+    "User-Agent": LAMBDA_USER_AGENT,
   };
 
   const req = https.request(options, (res) => {

--- a/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
+++ b/upsertGitHubTag-f79c4f36-3e61-43f4-8f6c-0b2e0e9774d7/deployment/index.js
@@ -34,6 +34,7 @@ function postEndpoint(path, postBody, callback) {
   options.headers = {
     "Content-Type": "application/x-www-form-urlencoded",
     Authorization: "Bearer " + process.env.DOCKSTORE_TOKEN,
+    "User-Agent": "NodeJs Dockstore Lambda",
   };
 
   const req = https.request(options, (res) => {
@@ -86,6 +87,7 @@ function deleteEndpoint(
   options.method = "DELETE";
   options.headers = {
     Authorization: "Bearer " + process.env.DOCKSTORE_TOKEN,
+    "User-Agent": "NodeJs Dockstore Lambda",
   };
 
   const req = https.request(options, (res) => {


### PR DESCRIPTION
https://ucsc-cgl.atlassian.net/browse/SEAB-2511

We could also use an accept browser user-agent. For now, this seems the most explicit.