### PR TITLE
Feature/3057/inventory lambda changes

### DIFF
--- a/fedramp-integrated-inventory-workbook/deployment/inventory/mappers.py
+++ b/fedramp-integrated-inventory-workbook/deployment/inventory/mappers.py
@@ -265,3 +265,12 @@ class LambdaDataMapper(DataMapper):
                 }
 
         return [InventoryData(**data)]
+
+
+class ElasticSearchDataMapper(DataMapper):
+    def _get_supported_resource_type(self) -> List[str]:
+        return ["AWS::Elasticsearch::Domain"]
+
+    def _do_mapping(self, config_resource: dict) -> List[InventoryData]:
+        data = {}
+        return [InventoryData(**data)]

--- a/fedramp-integrated-inventory-workbook/deployment/inventory/mappers.py
+++ b/fedramp-integrated-inventory-workbook/deployment/inventory/mappers.py
@@ -272,5 +272,14 @@ class ElasticSearchDataMapper(DataMapper):
         return ["AWS::Elasticsearch::Domain"]
 
     def _do_mapping(self, config_resource: dict) -> List[InventoryData]:
-        data = {}
+        data = {"asset_type": "Elastic Search",
+                "unique_id": config_resource["arn"],
+                "is_virtual": "Yes",
+                "is_public": "No",
+                "baseline_config": config_resource["configuration"]["elasticsearchVersion"],
+                "software_vendor": "AWS",
+                "software_product_name": "Elastic Search",
+                "asset_tag": config_resource["resourceName"] if "resourceName" in config_resource else config_resource["resourceId"],
+                "owner": _get_tag_value(config_resource["tags"], "owner"),
+                "location": config_resource["awsRegion"]}
         return [InventoryData(**data)]

--- a/fedramp-integrated-inventory-workbook/deployment/inventory/readers.py
+++ b/fedramp-integrated-inventory-workbook/deployment/inventory/readers.py
@@ -5,7 +5,7 @@ from typing import Iterator, List, Optional
 import boto3
 from botocore.exceptions import ClientError
 from .mappers import DataMapper, EC2DataMapper, ElbDataMapper, DynamoDbTableDataMapper, InventoryData, RdsDataMapper, S3DataMapper, \
-    VPCDataMapper, LambdaDataMapper
+    VPCDataMapper, LambdaDataMapper, ElasticSearchDataMapper
 
 _logger = logging.getLogger("inventory.readers")
 _logger.setLevel(os.environ.get("LOG_LEVEL", logging.INFO))
@@ -15,7 +15,7 @@ class AwsConfigInventoryReader():
     def __init__(self, lambda_context, mappers=None):
         if mappers is None:
             mappers = [EC2DataMapper(), ElbDataMapper(), DynamoDbTableDataMapper(), RdsDataMapper(), S3DataMapper(), VPCDataMapper(),
-                       LambdaDataMapper()]
+                       LambdaDataMapper(), ElasticSearchDataMapper()]
         self._lambda_context = lambda_context
         self._mappers: List[DataMapper] = mappers
 
@@ -90,7 +90,6 @@ class AwsConfigInventoryReader():
 
                     if not mapper:
                         _logger.warning(f"skipping mapping, unable to find mapper for resource type of {resource['resourceType']}")
-
                         continue
 
                     if len(inventory_items := mapper.map(resource)) > 0:

--- a/fedramp-integrated-inventory-workbook/deployment/inventory/readers.py
+++ b/fedramp-integrated-inventory-workbook/deployment/inventory/readers.py
@@ -98,4 +98,12 @@ class AwsConfigInventoryReader():
 
         _logger.info(f"completed getting inventory, with a total of {len(all_inventory)}")
 
+        # Add the manual items listed as an environment variable
+        manual_entry_items = json.loads(os.environ["MANUAL_ENTRY_ITEMS"])
+        for item in manual_entry_items:
+            manual_inventory_item = InventoryData()
+            for key in item:
+                setattr(manual_inventory_item, key, item[key])
+            all_inventory.append(manual_inventory_item)
+
         return all_inventory

--- a/fedramp-integrated-inventory-workbook/deployment/inventory/readers.py
+++ b/fedramp-integrated-inventory-workbook/deployment/inventory/readers.py
@@ -38,6 +38,7 @@ class AwsConfigInventoryReader():
 
             for region in region_list:
                 config_client = self._get_config_client(sts_response, region)
+                _logger.info(f"assuming role on account {account_id} for region {region}")
 
                 next_token: str = ''
                 while True:
@@ -51,7 +52,7 @@ class AwsConfigInventoryReader():
                     next_token = resources_result.get('NextToken', '')
                     results: List[str] = resources_result.get('Results', [])
 
-                    _logger.debug(f"page returned {len(results)} and next token of '{next_token}'")
+                    _logger.debug(f"Region {region} page returned {len(results)} and next token of '{next_token}'")
 
                     yield results
 

--- a/fedramp-integrated-inventory-workbook/deployment/inventory/readers.py
+++ b/fedramp-integrated-inventory-workbook/deployment/inventory/readers.py
@@ -21,40 +21,43 @@ class AwsConfigInventoryReader():
         self._mappers: List[DataMapper] = mappers
 
     # Moved into it's own method to make it easier to mock boto3 client
-    def _get_config_client(self, sts_response) -> boto3.client:
+    def _get_config_client(self, sts_response, region: str) -> boto3.client:
         sts_response = sts_response.get_frozen_credentials()
         return boto3.client('config',
                             aws_access_key_id=sts_response.access_key,
                             aws_secret_access_key=sts_response.secret_key,
                             aws_session_token=sts_response.token,
-                            region_name=os.environ['AWS_REGION'])
+                            region_name=region)
 
-    def _get_resources_from_account(self, account_id: str) -> Iterator[List[str]]:
+    def _get_resources_from_account(self, account_id: str, region_list: List[str]) -> Iterator[List[str]]:
         try:
             _logger.info(f"assuming role on account {account_id}")
 
             # get the credentials for the current role assumed by the lambda
             sts_response = boto3.Session().get_credentials()
-            config_client = self._get_config_client(sts_response)
 
-            next_token: str = ''
-            while True:
-                resources_result = config_client.select_resource_config(
-                    Expression="SELECT arn, resourceName, resourceId, resourceType, configuration, supplementaryConfiguration, configurationStateId, tags, awsRegion "
-                               "WHERE resourceType IN ('AWS::EC2::Instance', 'AWS::ElasticLoadBalancingV2::LoadBalancer', "
-                               "'AWS::ElasticLoadBalancing::LoadBalancer', 'AWS::RDS::DBInstance', "
-                               "'AWS::Lambda::Function', 'AWS::EC2::VPC', 'AWS::S3::Bucket')",
-                    NextToken=next_token)
+            for region in region_list:
+                config_client = self._get_config_client(sts_response, region)
 
-                next_token = resources_result.get('NextToken', '')
-                results: List[str] = resources_result.get('Results', [])
+                next_token: str = ''
+                while True:
+                    resources_result = config_client.select_resource_config(
+                        Expression="SELECT arn, resourceName, resourceId, resourceType, configuration, supplementaryConfiguration, configurationStateId, tags, awsRegion "
+                                   "WHERE resourceType IN ('AWS::EC2::Instance', 'AWS::ElasticLoadBalancingV2::LoadBalancer', "
+                                   "'AWS::ElasticLoadBalancing::LoadBalancer', 'AWS::RDS::DBInstance', "
+                                   "'AWS::Lambda::Function', 'AWS::EC2::VPC', 'AWS::S3::Bucket')",
+                        NextToken=next_token)
 
-                _logger.debug(f"page returned {len(results)} and next token of '{next_token}'")
+                    next_token = resources_result.get('NextToken', '')
+                    results: List[str] = resources_result.get('Results', [])
 
-                yield results
+                    _logger.debug(f"page returned {len(results)} and next token of '{next_token}'")
 
-                if not next_token:
-                    break
+                    yield results
+
+                    if not next_token:
+                        break
+
         except ClientError as ex:
             _logger.error("Received error: %s while retrieving resources from account %s, moving onto next account.", ex, account_id,
                           exc_info=True)
@@ -71,11 +74,12 @@ class AwsConfigInventoryReader():
 
         all_inventory: List[InventoryData] = []
         accounts = json.loads(os.environ["ACCOUNT_LIST"])
+        region_list = accounts["regions"]
 
         for account in accounts:
-            _logger.info(f"retrieving inventory for account {account['id']}")
+            _logger.info(f"retrieving inventory for account {account['id']} in regions {region_list}")
 
-            for resource_list_page in self._get_resources_from_account(account["id"]):
+            for resource_list_page in self._get_resources_from_account(account["id"], region_list):
                 _logger.debug(f"current page of inventory contained {len(resource_list_page)} items from AWS Config")
 
                 for raw_resource in resource_list_page:

--- a/fedramp-integrated-inventory-workbook/deployment/inventory/readers.py
+++ b/fedramp-integrated-inventory-workbook/deployment/inventory/readers.py
@@ -8,7 +8,7 @@ from .mappers import DataMapper, EC2DataMapper, ElbDataMapper, DynamoDbTableData
     VPCDataMapper, LambdaDataMapper, ElasticSearchDataMapper
 
 _logger = logging.getLogger("inventory.readers")
-_logger.setLevel(os.environ.get("LOG_LEVEL", logging.INFO))
+_logger.setLevel(os.environ.get("LOG_LEVEL", logging.DEBUG))
 
 
 class AwsConfigInventoryReader():
@@ -85,6 +85,7 @@ class AwsConfigInventoryReader():
 
                     # One line item returned from AWS Config can result in multiple inventory line items (e.g. multiple IPs)
                     # Mappers that do not support the resource type will return False
+                    _logger.debug(f"Searching for mapper for resource type: {resource['resourceType']}")
                     mapper: Optional[DataMapper] = next((mapper for mapper in self._mappers if mapper.can_map(resource["resourceType"])),
                                                         None)
 

--- a/fedramp-integrated-inventory-workbook/deployment/inventory/readers.py
+++ b/fedramp-integrated-inventory-workbook/deployment/inventory/readers.py
@@ -74,9 +74,9 @@ class AwsConfigInventoryReader():
 
         all_inventory: List[InventoryData] = []
         accounts = json.loads(os.environ["ACCOUNT_LIST"])
-        region_list = accounts["regions"]
 
         for account in accounts:
+            region_list = account["regions"]
             _logger.info(f"retrieving inventory for account {account['id']} in regions {region_list}")
 
             for resource_list_page in self._get_resources_from_account(account["id"], region_list):

--- a/fedramp-integrated-inventory-workbook/deployment/inventory/readers.py
+++ b/fedramp-integrated-inventory-workbook/deployment/inventory/readers.py
@@ -8,7 +8,7 @@ from .mappers import DataMapper, EC2DataMapper, ElbDataMapper, DynamoDbTableData
     VPCDataMapper, LambdaDataMapper
 
 _logger = logging.getLogger("inventory.readers")
-_logger.setLevel(os.environ.get("LOG_LEVEL", logging.INFO))
+_logger.setLevel(os.environ.get("LOG_LEVEL", logging.DEBUG))
 
 
 class AwsConfigInventoryReader():

--- a/fedramp-integrated-inventory-workbook/deployment/inventory/readers.py
+++ b/fedramp-integrated-inventory-workbook/deployment/inventory/readers.py
@@ -21,7 +21,6 @@ class AwsConfigInventoryReader():
 
     # Moved into it's own method to make it easier to mock boto3 client
     def _get_config_client(self, sts_response, region: str) -> boto3.client:
-        sts_response = sts_response.get_frozen_credentials()
         return boto3.client('config',
                             aws_access_key_id=sts_response.access_key,
                             aws_secret_access_key=sts_response.secret_key,
@@ -32,18 +31,11 @@ class AwsConfigInventoryReader():
         try:
             _logger.info(f"assuming role on account {account_id}")
 
-            # get the credentials for the current role assumed by the lambda
-            sts_response = boto3.Session().get_credentials()
-
             for region in region_list:
-                curr_client = boto3.client('sts', region_name=region)
                 sts_response = boto3.Session().get_credentials()
                 config_client = self._get_config_client(sts_response, region)
 
-                my_session = boto3.session.Session()
-                my_region = my_session.region_name
-
-                _logger.info(f"assuming role on account {account_id} for region {my_region}")
+                _logger.info(f"Querying resources on account {account_id} for region {region}")
 
                 next_token: str = ''
                 while True:

--- a/fedramp-integrated-inventory-workbook/deployment/inventory/readers.py
+++ b/fedramp-integrated-inventory-workbook/deployment/inventory/readers.py
@@ -8,7 +8,7 @@ from .mappers import DataMapper, EC2DataMapper, ElbDataMapper, DynamoDbTableData
     VPCDataMapper, LambdaDataMapper
 
 _logger = logging.getLogger("inventory.readers")
-_logger.setLevel(os.environ.get("LOG_LEVEL", logging.DEBUG))
+_logger.setLevel(os.environ.get("LOG_LEVEL", logging.INFO))
 
 
 class AwsConfigInventoryReader():

--- a/fedramp-integrated-inventory-workbook/deployment/inventory/reports.py
+++ b/fedramp-integrated-inventory-workbook/deployment/inventory/reports.py
@@ -10,7 +10,7 @@ from openpyxl.utils import get_column_letter
 from .mappers import InventoryData
 
 _logger = logging.getLogger("inventory.reports")
-_logger.setLevel(os.environ.get("LOG_LEVEL", logging.DEBUG))
+_logger.setLevel(os.environ.get("LOG_LEVEL", logging.INFO))
 _current_dir_name = os.path.dirname(__file__)
 _workbook_template_file_name = os.path.join(_current_dir_name, "SSP-A13-FedRAMP-Integrated-Inventory-Workbook-Template.xlsx")
 _workbook_output_file_path = PurePath("/tmp/SSP-A13-FedRAMP-Integrated-Inventory.xlsx")

--- a/fedramp-integrated-inventory-workbook/deployment/inventory/reports.py
+++ b/fedramp-integrated-inventory-workbook/deployment/inventory/reports.py
@@ -10,7 +10,7 @@ from openpyxl.utils import get_column_letter
 from .mappers import InventoryData
 
 _logger = logging.getLogger("inventory.reports")
-_logger.setLevel(os.environ.get("LOG_LEVEL", logging.INFO))
+_logger.setLevel(os.environ.get("LOG_LEVEL", logging.DEBUG))
 _current_dir_name = os.path.dirname(__file__)
 _workbook_template_file_name = os.path.join(_current_dir_name, "SSP-A13-FedRAMP-Integrated-Inventory-Workbook-Template.xlsx")
 _workbook_output_file_path = PurePath("/tmp/SSP-A13-FedRAMP-Integrated-Inventory.xlsx")

--- a/fedramp-integrated-inventory-workbook/tests/sample_config_query_results/sample_es.json
+++ b/fedramp-integrated-inventory-workbook/tests/sample_config_query_results/sample_es.json
@@ -1,0 +1,108 @@
+{
+  "version": "1.3",
+  "accountId": "123456789",
+  "configurationItemCaptureTime": "2021-07-08T20:42:22.993Z",
+  "configurationItemStatus": "OK",
+  "configurationStateId": "0987654321",
+  "configurationItemMD5Hash": "",
+  "arn": "arn:aws:es:us-west-2:123456789:domain/my-elasticsearch",
+  "resourceType": "AWS::Elasticsearch::Domain",
+  "resourceId": "123456789/my-elasticsearch",
+  "resourceName": "my-elasticsearch",
+  "awsRegion": "us-west-2",
+  "availabilityZone": "Multiple Availability Zones",
+  "tags": {
+    "Environment": "custom"
+  },
+  "relatedEvents": [],
+  "relationships": [],
+  "configuration": {
+    "domainId": "123456789/my-elasticsearch",
+    "domainName": "my-elasticsearch",
+    "created": true,
+    "deleted": false,
+    "endpoints": {
+      "vpc": "vpc-my-elasticsearch-vpcid.us-west-2.es.amazonaws.com"
+    },
+    "processing": false,
+    "upgradeProcessing": false,
+    "elasticsearchVersion": "7.10",
+    "elasticsearchClusterConfig": {
+      "instanceType": "t3.medium.elasticsearch",
+      "instanceCount": 1,
+      "dedicatedMasterEnabled": false,
+      "zoneAwarenessEnabled": false,
+      "warmEnabled": false,
+      "coldStorageOptions": {
+        "enabled": false
+      }
+    },
+    "accessPolicies": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Action\":\"*\",\"Resource\":\"*\"}]}",
+    "snapshotOptions": {
+      "automatedSnapshotStartHour": 0
+    },
+    "cognitoOptions": {
+      "enabled": false
+    },
+    "encryptionAtRestOptions": {
+      "enabled": false
+    },
+    "nodeToNodeEncryptionOptions": {
+      "enabled": true
+    },
+    "advancedOptions": {
+      "rest.action.multi.allow_explicit_index": "true"
+    },
+    "logPublishingOptions": {
+      "ES_APPLICATION_LOGS": {
+        "cloudWatchLogsLogGroupArn": "arn:aws:logs:us-west-2:123456789:log-group:/aws/aes/domains/application-logs:*",
+        "enabled": true
+      }
+    },
+    "serviceSoftwareOptions": {
+      "currentVersion": "R20210426",
+      "newVersion": "R20210426-P2",
+      "updateAvailable": true,
+      "cancellable": false,
+      "updateStatus": "ELIGIBLE",
+      "description": "A new software release R20210426-P2 is available. This release will be automatically deployed if no action is taken.",
+      "automatedUpdateDate": 1625731585000,
+      "optionalDeployment": false
+    },
+    "domainEndpointOptions": {
+      "enforceHTTPS": false,
+      "customEndpointEnabled": false,
+      "tlssecurityPolicy": "Policy-Min-TLS-1-0-2019-07"
+    },
+    "advancedSecurityOptions": {
+      "enabled": false,
+      "internalUserDatabaseEnabled": false
+    },
+    "autoTuneOptions": {
+      "state": "ENABLE_IN_PROGRESS"
+    },
+    "arn": "arn:aws:es:us-west-2:123456789:domain/my-elasticsearch",
+    "ebsoptions": {
+      "volumeType": "gp2",
+      "volumeSize": 50,
+      "ebsenabled": true
+    },
+    "vpcoptions": {
+      "subnetIds": [
+        "subnet-abcdefghijklmnop"
+      ],
+      "availabilityZones": [
+        "us-west-2a"
+      ],
+      "securityGroupIds": [
+        "sg-abcdefghijklmnop"
+      ],
+      "vpcid": "vpc-abcdefghijklmnop"
+    }
+  },
+  "supplementaryConfiguration": {
+    "Tags": [
+    ]
+  },
+  "resourceTransitionStatus": "None"
+}

--- a/fedramp-integrated-inventory-workbook/tests/sample_config_query_results/sample_es.json
+++ b/fedramp-integrated-inventory-workbook/tests/sample_config_query_results/sample_es.json
@@ -55,7 +55,7 @@
     },
     "logPublishingOptions": {
       "ES_APPLICATION_LOGS": {
-        "cloudWatchLogsLogGroupArn": "arn:aws:logs:us-west-2:123456789:log-group:/aws/aes/domains/application-logs:*",
+        "cloudWatchLogsLogGroupArn": "arn:aws:logs:us-west-2:123456789:log-group:/logs:*",
         "enabled": true
       }
     },
@@ -92,7 +92,7 @@
         "subnet-abcdefghijklmnop"
       ],
       "availabilityZones": [
-        "us-west-2a"
+        "us-west-2b"
       ],
       "securityGroupIds": [
         "sg-abcdefghijklmnop"

--- a/fedramp-integrated-inventory-workbook/tests/test_elastic_search_mapper.py
+++ b/fedramp-integrated-inventory-workbook/tests/test_elastic_search_mapper.py
@@ -4,7 +4,7 @@ import pytest
 from inventory.mappers import ElasticSearchDataMapper
 
 @pytest.fixture()
-def full_classic_es_config():
+def full_es_config():
     with open(os.path.join(os.path.dirname(__file__), "sample_config_query_results/sample_es.json")) as file_data:
         file_contents = file_data.read()
 

--- a/fedramp-integrated-inventory-workbook/tests/test_elastic_search_mapper.py
+++ b/fedramp-integrated-inventory-workbook/tests/test_elastic_search_mapper.py
@@ -4,33 +4,33 @@ import pytest
 from inventory.mappers import ElasticSearchDataMapper
 
 @pytest.fixture()
-def full_classic_elb_config():
-    with open(os.path.join(os.path.dirname(__file__), "sample_config_query_results/sample_elastic_search.json")) as file_data:
+def full_classic_es_config():
+    with open(os.path.join(os.path.dirname(__file__), "sample_config_query_results/sample_es.json")) as file_data:
         file_contents = file_data.read()
 
     return json.loads(file_contents)
 
-def test_given_elastic_search_then_base_attributes_mapped(full_ES_config):
+def test_given_elastic_search_then_base_attributes_mapped(full_es_config):
     mapper = ElasticSearchDataMapper()
 
-    mapped_result = mapper.map(full_ES_config)
+    mapped_result = mapper.map(full_es_config)
 
     assert len(mapped_result) == 1, "Expected one row to be mapped"
-    assert mapped_result[0].unique_id == full_ES_config["arn"], "ARN should be mapped to unique id"
+    assert mapped_result[0].unique_id == full_es_config["arn"], "ARN should be mapped to unique id"
 
-def test_given_elastic_search_then_configuration_noted(full_ES_config):
+def test_given_elastic_search_then_configuration_noted(full_es_config):
     mapper = ElasticSearchDataMapper()
 
-    mapped_result = mapper.map(full_ES_config)
+    mapped_result = mapper.map(full_es_config)
 
     assert len(mapped_result) == 1, "Expected one row to be mapped"
-    assert mapped_result[0].baseline_config == full_ES_config["configuration"]["elasticsearchVersion"], "ElasticSearch version should be noted"
+    assert mapped_result[0].baseline_config == full_es_config["configuration"]["elasticsearchVersion"], "ElasticSearch version should be noted"
 
-def test_given_elastic_search_then_user_friendly_name_recorded(full_ES_config):
+def test_given_elastic_search_then_user_friendly_name_recorded(full_es_config):
     mapper = ElasticSearchDataMapper()
 
-    mapped_result = mapper.map(full_ES_config)
+    mapped_result = mapper.map(full_es_config)
 
     assert len(mapped_result) == 1, "Expected one row to be mapped"
-    assert mapped_result[0].asset_tag == full_ES_config["resourceName"], "ElasticSearch resource name should be noted"
+    assert mapped_result[0].asset_tag == full_es_config["resourceName"], "ElasticSearch resource name should be noted"
 

--- a/fedramp-integrated-inventory-workbook/tests/test_elastic_search_mapper.py
+++ b/fedramp-integrated-inventory-workbook/tests/test_elastic_search_mapper.py
@@ -1,0 +1,36 @@
+import json
+import os
+import pytest
+from inventory.mappers import ElasticSearchDataMapper
+
+@pytest.fixture()
+def full_classic_elb_config():
+    with open(os.path.join(os.path.dirname(__file__), "sample_config_query_results/sample_elastic_search.json")) as file_data:
+        file_contents = file_data.read()
+
+    return json.loads(file_contents)
+
+def test_given_elastic_search_then_base_attributes_mapped(full_ES_config):
+    mapper = ElasticSearchDataMapper()
+
+    mapped_result = mapper.map(full_ES_config)
+
+    assert len(mapped_result) == 1, "Expected one row to be mapped"
+    assert mapped_result[0].unique_id == full_ES_config["arn"], "ARN should be mapped to unique id"
+
+def test_given_elastic_search_then_configuration_noted(full_ES_config):
+    mapper = ElasticSearchDataMapper()
+
+    mapped_result = mapper.map(full_ES_config)
+
+    assert len(mapped_result) == 1, "Expected one row to be mapped"
+    assert mapped_result[0].baseline_config == full_ES_config["configuration"]["elasticsearchVersion"], "ElasticSearch version should be noted"
+
+def test_given_elastic_search_then_user_friendly_name_recorded(full_ES_config):
+    mapper = ElasticSearchDataMapper()
+
+    mapped_result = mapper.map(full_ES_config)
+
+    assert len(mapped_result) == 1, "Expected one row to be mapped"
+    assert mapped_result[0].asset_tag == full_ES_config["resourceName"], "ElasticSearch resource name should be noted"
+


### PR DESCRIPTION
Ticket: https://ucsc-cgl.atlassian.net/browse/SEAB-3057
Partner PR: https://github.com/dockstore/dockstore-deploy/pull/289

This adds some additional functionality to the inventory lambda, mainly:
1.  Will query multiple regions simultaneously.
2.  Will accept an environment variable that contains a JSON of manual entry items.
3. Added mappings for AWS ElasticSearch

The environment variable `MANUAL_ENTRY_ITEMS` is an easy approach right now to pass in manual entry items, it is currently defined in the CF template for the inventory collector, but if we end up with much more than 2 manual entry items, we may want to consider a different approach.