### PR TITLE
Modify test for Mac

### DIFF
--- a/nextflow-parsing/NextflowParsingFunction/src/test/java/io/dockstore/nextflowparsing/AppTest.java
+++ b/nextflow-parsing/NextflowParsingFunction/src/test/java/io/dockstore/nextflowparsing/AppTest.java
@@ -54,7 +54,7 @@ public class AppTest {
     assertNotNull(response.getVersionTypeValidation().isValid());
     assertTrue(response.getVersionTypeValidation().isValid());
     assertNotNull(response.getClonedRepositoryAbsolutePath());
-    assertTrue(response.getClonedRepositoryAbsolutePath().contains("/tmp"));
+    assertTrue(response.getClonedRepositoryAbsolutePath().contains("clonedRepository"));
     assertNotNull(response.getSecondaryFilePaths());
     final int knownSecondaryFilesCount = 23;
     assertEquals(


### PR DESCRIPTION
Modify the test so that it should also work for Mac. Someone with a mac needs to test this:

Don't use sam build --use-container to test, it runs in its own container

This is the Nextflow parsing lambda tests