### PR TITLE
Display SQS message ID for easier search in CloudWatch

### DIFF
--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -149,6 +149,16 @@ function processEvent(event, callback) {
   var loneEvent = event.Records[0];
   var requestBody = JSON.parse(loneEvent.body);
 
+  // Print SQS message ID if it is there
+  if (
+    Object.prototype.hasOwnProperty.call(loneEvent, "messageId") &&
+    loneEvent["messageId"]
+  ) {
+    const messageId = loneEvent.messageId;
+    const messageText = `message ID is: ${messageId}`;
+    console.log(messageText);
+  }
+
   // The payload is encoded in base64
   const buff = Buffer.from(requestBody.payload, "base64");
   const bodyDecoded = buff.toString("utf8");


### PR DESCRIPTION
If we include the SQS message ID in a CloudWatch console message it will be easier to find entries in CloudWatch where GitHub Apps pushes, etc. have been retried after failing. The initial SQS message that triggers the Upsert Lambda includes the message id. If the Lambda fails SQS triggers another call to the Lambda after an hour and includes the original SQS message ID.  We can use the message id to locate the original Lambda execution that fails, and the retry call(s) to the Lambda.