### PR TITLE
switch to openid connect

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,7 @@ orbs:
   aws-s3: circleci/aws-s3@3.0.0
   node: circleci/node@4.7.0
   sam: circleci/aws-sam-serverless@3.0
+  aws-cli: circleci/aws-cli@3.1.1 # perform openid connect  
 jobs:
   build:
     docker:
@@ -14,7 +15,12 @@ jobs:
     steps:
       - when:
           condition: <<parameters.aws_bucket>>
+          executor: aws-cli/default
           steps:
+            - aws-cli/setup:
+                profile-name: WEB IDENTITY PROFILE
+                role-arn: $AWS_ROLE_ARN
+                role-session-name: "CircleCI-${CIRCLE_WORKFLOW_ID}-${CIRCLE_JOB}"          
             - checkout
             - node/install:
                 install-yarn: false
@@ -51,7 +57,12 @@ jobs:
     steps:
       - when:
           condition: <<parameters.aws_bucket>>
+          executor: aws-cli/default
           steps:
+            - aws-cli/setup:
+                profile-name: WEB IDENTITY PROFILE
+                role-arn: $AWS_ROLE_ARN
+                role-session-name: "CircleCI-${CIRCLE_WORKFLOW_ID}-${CIRCLE_JOB}"          
             - checkout
             - run:
                 name: Validate index.js
@@ -204,7 +215,7 @@ workflows:
             tags:
               only: /.*/
           context:
-            - aws-lambda
+            - aws-lambda-v2
       - js_tests:
           filters:
             tags:
@@ -218,4 +229,4 @@ workflows:
             tags:
               only: /.*/
           context:
-            - aws-lambda
+            - aws-lambda-v2

--- a/wdl-parsing/WDLParsingFunction/pom.xml
+++ b/wdl-parsing/WDLParsingFunction/pom.xml
@@ -30,6 +30,11 @@
             <id>jgit-repository</id>
             <url>https://repo.eclipse.org/content/groups/releases/</url>
         </repository>
+        <repository>
+            <id>artifacts.oicr.on.ca</id>
+            <name>artifacts.oicr.on.ca</name>
+	    <url>https://artifacts.oicr.on.ca/artifactory/collab-release</url>
+        </repository>
     </repositories>
     <dependencies>
         <dependency>


### PR DESCRIPTION
more https://ucsc-cgl.atlassian.net/browse/SEAB-4284

on merge, will deactivate keys in old context

--------------------
separately, looks like broad has deleted an old dependency so I had to upload it to artifacts to get the build to pass