### PR TITLE
Allow simple unstructured slack messages

### DIFF
--- a/cloud-watch-to-slack-testing/deployment/index.js
+++ b/cloud-watch-to-slack-testing/deployment/index.js
@@ -234,6 +234,9 @@ function s3ActivityMessageText(message) {
 }
 
 function messageTextFromMessage(message) {
+  if (typeof message !== "object") {
+    return message;
+  }
   if (message.source === "aws.config") {
     return awsConfigMessageText(message);
   } else if (message.source === "aws.trustedadvisor") {
@@ -291,7 +294,12 @@ function setSlackChannelBasedOnSNSTopic(topicArn) {
 
 function processEvent(event, callback) {
   console.log(event);
-  const message = JSON.parse(event.Records[0].Sns.Message);
+  var message;
+  try {
+    message = JSON.parse(event.Records[0].Sns.Message);
+  } catch (e) {
+    message = event.Records[0].Sns.Message;
+  }
   const topicArn = event.Records[0].Sns.TopicArn;
   const slackChannel = setSlackChannelBasedOnSNSTopic(topicArn);
   console.info("Slack channel is " + slackChannel);

--- a/cloud-watch-to-slack-testing/deployment/index.js
+++ b/cloud-watch-to-slack-testing/deployment/index.js
@@ -233,10 +233,7 @@ function s3ActivityMessageText(message) {
   return `${userName} generated S3 event ${eventName} from region ${awsRegion} for bucket ${bucketName} in Dockstore ${dockstoreEnvironment}`;
 }
 
-function messageTextFromMessage(message) {
-  if (typeof message !== "object") {
-    return message;
-  }
+function messageTextFromMessageObject(message) {
   if (message.source === "aws.config") {
     return awsConfigMessageText(message);
   } else if (message.source === "aws.trustedadvisor") {
@@ -294,17 +291,19 @@ function setSlackChannelBasedOnSNSTopic(topicArn) {
 
 function processEvent(event, callback) {
   console.log(event);
-  var message;
+  let message;
+  let messageText;
   try {
     message = JSON.parse(event.Records[0].Sns.Message);
+    messageText = messageTextFromMessageObject(message);
   } catch (e) {
     message = event.Records[0].Sns.Message;
+    messageText = message;
   }
   const topicArn = event.Records[0].Sns.TopicArn;
   const slackChannel = setSlackChannelBasedOnSNSTopic(topicArn);
   console.info("Slack channel is " + slackChannel);
 
-  const messageText = messageTextFromMessage(message);
   if (addInstanceDetails(message)) {
     const targetInstanceId = message.detail.requestParameters.target;
     getInstanceNameAndSendMsgToSlack(

--- a/cloud-watch-to-slack-testing/deployment/index.js
+++ b/cloud-watch-to-slack-testing/deployment/index.js
@@ -298,6 +298,7 @@ function processEvent(event, callback) {
     messageText = messageTextFromMessageObject(message);
   } catch (e) {
     message = event.Records[0].Sns.Message;
+    console.log("Plain message received: " + messageText);
     messageText = message;
   }
   const topicArn = event.Records[0].Sns.TopicArn;


### PR DESCRIPTION
This is a change to support sending simple unstructured messages via SNS that can appear in slack. In this case, an SSM automation prepares the content of the message instead of requiring the lambda to format a slack readable message.

Used by an SSM document to be added at dockstore-deploy https://github.com/dockstore/dockstore-deploy/pull/481. This change is currently in test in dev.

https://ucsc-cgl.atlassian.net/browse/SEAB-3465