### PR TITLE
DOCK-2126: Fix weird github apps lambda behavior

### DIFF
--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -205,6 +205,7 @@ function processEvent(event, callback) {
         statusCode: 200,
         body: "Currently, this lambda does not support this event type from GitHub.",
       });
+      return;
     }
 
     // A push has been made for some repository (ignore pushes that are deletes)

--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -269,8 +269,6 @@ function processEvent(event, callback) {
         " from GitHub.",
     });
   }
-
-  callback(null, { statusCode: 200, body: "results" });
 }
 
 // Handle response from Dockstore webservice


### PR DESCRIPTION
This PR fixes the strange behavior that was reported in https://ucsc-cgl.atlassian.net/browse/DOCK-2126 dockstore/dockstore#4831.

TLDR: The lambda was not retrying requests when it received a 5xx from the webservice, causing pushes to be lost.  This PR fixes it.  And it's a negative-one-liner w00t!

A node.js lambda handler method is passed a callback, which is used by the lambda to return a result or signal an error condition:
https://docs.aws.amazon.com/lambda/latest/dg/nodejs-handler.html

After much investigation, I determined that the line that I removed was being executed before most other callback invocations, essentially preempting all subsequent retry decisions (most (all?) of which are made in event handlers).  Valid requests were only being retried in the relatively-rare case that the lambda itself threw an error (such as from the https lib if it couldn't connect to the server).

I confirmed this behavior with various experiments on the running dev lambda.

At first, I wanted to do a fairly extensive refactor, but I decided to keep things simple, not break anything, and focus the effort on more pressing matters.  We could add code to handle http network errors (`req.on("error")` ...), but I'm actually fine with the exception propagating outwards, and being handled by the queuing system (which correctly retries on exceptions).

Things I think I sorta might know about AWS lambdas, now:

1. The first callback invocation takes precedence over the rest.
2. Regarding retries, the queuing system only cares if the lambda error-ed, or not.  The statusCodes and messages that the lambda returns would be useful to the API Gateway service, but they don't matter to the queuing system.

I could be wrong about either, especially number 2.  AWS docs are not thorough and the hivemind does not offer clear, unanimous advice.

We should improve our lambda testing.  I'd add some, but this is my inaugural lambda PR, so I don't really have much insight about that, yet.  Given the scope, user testing it on dev should be fine...