### PR TITLE
Format message for ECS Exec

### DIFF
--- a/cloud-watch-to-slack-testing/deployment/index.js
+++ b/cloud-watch-to-slack-testing/deployment/index.js
@@ -198,7 +198,10 @@ function ssmOrSigninMessageText(message) {
     } else if (message.detail.userIdentity.type === "AssumedRole") {
       const accountId = message.detail.userIdentity.accountId;
       // Don't display account ID
-      user = message.detail.userIdentity.arn.replace(accountId, "X".repeat(accountId.length));
+      user = message.detail.userIdentity.arn.replace(
+        accountId,
+        "X".repeat(accountId.length)
+      );
     }
     messageText = `${user} initiated AWS Systems Manager (SSM) event ${eventName}`;
   } else if (message.source === "aws.signin") {


### PR DESCRIPTION
**Description**
Related to PR https://github.com/dockstore/dockstore-deploy/pull/542. This PR formats the message for an ssm session started by ECS Exec.

The message looks like: 

`arn:aws:sts::XXXXXXXXXXXX:assumed-role/AWSServiceRoleForECS/ecs-execute-command initiated AWS Systems Manager (SSM) event StartSession on Dockstore <env> in region: <region>. Event was initiated from IP [ecs.amazonaws.com](http://ecs.amazonaws.com/) to target: ecs:kathysJump-JumpEcsClusterDF384D0A-dqqEjUbMoybX_db1ecf00b04040f885e71369cdffeebf_db1ecf00b04040f885e71369cdffeebf-3189133771`

**Issue**
[SEAB-4501](https://ucsc-cgl.atlassian.net/browse/SEAB-4501)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
