### PR TITLE
redirect pom

### DIFF
--- a/wdl-parsing/WDLParsingFunction/pom.xml
+++ b/wdl-parsing/WDLParsingFunction/pom.xml
@@ -27,9 +27,14 @@
             <layout>default</layout>
         </repository>
         <repository>
+            <id>artifacts.oicr.on.ca</id>
+            <name>artifacts.oicr.on.ca</name>
+            <url>https://artifacts.oicr.on.ca/artifactory/collab-release</url>
+        </repository>
+        <repository>
             <id>artifactory.broadinstitute.org</id>
             <name>artifactory.broadinstitute.org</name>
-            <url>https://artifactory.broadinstitute.org/artifactory/libs-release</url>
+            <url>https://broadinstitute.jfrog.io/artifactory/libs-release/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -40,11 +45,6 @@
         <repository>
             <id>jgit-repository</id>
             <url>https://repo.eclipse.org/content/groups/releases/</url>
-        </repository>
-        <repository>
-            <id>artifacts.oicr.on.ca</id>
-            <name>artifacts.oicr.on.ca</name>
-            <url>https://artifacts.oicr.on.ca/artifactory/collab-release</url>
         </repository>
     </repositories>
     <dependencies>


### PR DESCRIPTION
**Description**
Seems like the broad artifactory changed locations. We build the lambda during the dockstore tests, so needed an update

**Issue**
https://github.com/dockstore/dockstore/pull/5622

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
