### PR TITLE
SEAB-5770: Propagate installationId to webservice delete webhook endpoint

### DIFF
--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -74,6 +74,7 @@ function deleteEndpoint(
   repository,
   reference,
   username,
+  installationId,
   deliveryId,
   callback
 ) {
@@ -83,6 +84,7 @@ function deleteEndpoint(
   urlWithParams.searchParams.append("gitReference", reference);
   urlWithParams.searchParams.append("repository", repository);
   urlWithParams.searchParams.append("username", username);
+  urlWithParams.searchParams.append("installationId", installationId);
 
   const options = url.parse(urlWithParams.href);
   options.method = "DELETE";
@@ -219,6 +221,7 @@ function processEvent(event, callback) {
       const repository = body.repository.full_name;
       const gitReference = body.ref;
       const username = body.sender.login;
+      const installationId = body.installation.id;
 
       path += "workflows/github";
 
@@ -227,6 +230,7 @@ function processEvent(event, callback) {
         repository,
         gitReference,
         username,
+        installationId,
         deliveryId,
         (response) => {
           const successMessage =


### PR DESCRIPTION
**Description**
This PR extracts the GitHub App installation id from the event and passes it to the webservice delete webhook endpoint, which needs the installation id so it can connect to GitHub and check if the ref exists or not, as part of the implementation of https://ucsc-cgl.atlassian.net/browse/SEAB-5770

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5770

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
