### PR TITLE
SEAB-6000: Propagate both the "added" and "removed" varieties of the "installation_repositories" event

### DIFF
--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -171,7 +171,7 @@ function processEvent(event, callback) {
     path += "workflows/github/install";
     postEndpoint(path, body, deliveryId, (response) => {
       const added = body.action === "added"
-      repositories = full_names(added ? body.repositories_added ? body.repositories_removed)
+      repositories = full_names(added ? body.repositories_added : body.repositories_removed)
       const successMessage = `The GitHub app was successfully ${added ? "installed" : "uninstalled"} on repositories ${repositories}`
       handleCallback(response, successMessage, callback);
     });

--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -170,9 +170,13 @@ function processEvent(event, callback) {
     console.log("Valid installation event");
     path += "workflows/github/install";
     postEndpoint(path, body, deliveryId, (response) => {
-      const added = body.action === "added"
-      const repositories = (added ? body.repositories_added : body.repositories_removed).map((repo) => repo.full_name)
-      const successMessage = `The GitHub app was successfully ${added ? "installed" : "uninstalled"} on repositories ${repositories}`
+      const added = body.action === "added";
+      const repositories = (
+        added ? body.repositories_added : body.repositories_removed
+      ).map((repo) => repo.full_name);
+      const successMessage = `The GitHub app was successfully ${
+        added ? "installed" : "uninstalled"
+      } on repositories ${repositories}`;
       handleCallback(response, successMessage, callback);
     });
   } else if (githubEventType === "push") {

--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -166,24 +166,15 @@ function processEvent(event, callback) {
   var githubEventType = requestBody["X-GitHub-Event"];
   // Handle installation events
   if (githubEventType === "installation_repositories") {
-    // Currently ignoring repository removal events, only calling the endpoint if we are adding a repository.
-    if (body.action === "added") {
-      console.log("Valid installation event");
-      path += "workflows/github/install";
-      const repositoriesAdded = body.repositories_added;
-      const repositories = repositoriesAdded.map((repo) => repo.full_name);
-
-      postEndpoint(path, body, deliveryId, (response) => {
-        const successMessage =
-          "The GitHub app was successfully installed on repositories " +
-          repositories;
-        handleCallback(response, successMessage, callback);
-      });
-    } else {
-      console.log(
-        'installation_repositories event ignored "' + body.action + '" action'
-      );
-    }
+    // The installation_repositories event contains information about both additions and removals
+    console.log("Valid installation event");
+    path += "workflows/github/install";
+    postEndpoint(path, body, deliveryId, (response) => {
+      const added = body.action !== "removed"
+      repositories = full_names(added ? body.repositories_added ? body.repositories_removed)
+      const successMessage = `The GitHub app was successfully ${added ? "installed" : "uninstalled"} on repositories ${repositories}`
+      handleCallback(response, successMessage, callback);
+    });
   } else if (githubEventType === "push") {
     /**
      * We only handle push events, of which there are many subtypes. Unfortunately, the only way to differentiate between them is to look

--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -170,7 +170,7 @@ function processEvent(event, callback) {
     console.log("Valid installation event");
     path += "workflows/github/install";
     postEndpoint(path, body, deliveryId, (response) => {
-      const added = body.action !== "removed"
+      const added = body.action === "added"
       repositories = full_names(added ? body.repositories_added ? body.repositories_removed)
       const successMessage = `The GitHub app was successfully ${added ? "installed" : "uninstalled"} on repositories ${repositories}`
       handleCallback(response, successMessage, callback);

--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -171,7 +171,7 @@ function processEvent(event, callback) {
     path += "workflows/github/install";
     postEndpoint(path, body, deliveryId, (response) => {
       const added = body.action === "added"
-      repositories = full_names(added ? body.repositories_added : body.repositories_removed)
+      const repositories = (added ? body.repositories_added : body.repositories_removed).map((repo) => repo.full_name)
       const successMessage = `The GitHub app was successfully ${added ? "installed" : "uninstalled"} on repositories ${repositories}`
       handleCallback(response, successMessage, callback);
     });

--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -166,7 +166,7 @@ function processEvent(event, callback) {
   var githubEventType = requestBody["X-GitHub-Event"];
   // Handle installation events
   if (githubEventType === "installation_repositories") {
-    // The installation_repositories event contains information about both additions and removals
+    // The installation_repositories event contains information about both additions and removals.
     console.log("Valid installation event");
     path += "workflows/github/install";
     postEndpoint(path, body, deliveryId, (response) => {

--- a/wdl-parsing/WDLParsingFunction/pom.xml
+++ b/wdl-parsing/WDLParsingFunction/pom.xml
@@ -27,11 +27,6 @@
             <layout>default</layout>
         </repository>
         <repository>
-            <id>artifacts.oicr.on.ca</id>
-            <name>artifacts.oicr.on.ca</name>
-            <url>https://artifacts.oicr.on.ca/artifactory/collab-release</url>
-        </repository>
-        <repository>
             <id>artifactory.broadinstitute.org</id>
             <name>artifactory.broadinstitute.org</name>
             <url>https://broadinstitute.jfrog.io/artifactory/libs-release/</url>


### PR DESCRIPTION
**Description**
This PR changes the upsertGitHub lambda to propagate both possible varieties of the "installation_repositories" event (wherein the action is either "added" or "removed") to the webservice.

Regarding the code style, it's not how I would have formatted/indented the code, but that's what our tests require. 

Had remove the duplicate `<repository>` lines from that pom to make the tests pass.

After this PR merges, I will update `dockstore-deploy` to incorporate the corresponding commit.

**Review Instructions**
https://ucsc-cgl.atlassian.net/browse/SEAB-6000

**Testing**
See https://github.com/dockstore/dockstore/pull/5852

**Security**
No concerns.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
