### PR TITLE
SEAB-5604: fix date for the github lambda bucket

### DIFF
--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -267,7 +267,7 @@ function logPayloadToS3(body, deliveryId) {
   // If bucket name is not null (had to put this for the integration test)
   if (process.env.BUCKET_NAME) {
     const uploadDate = new Date();
-    const bucketPath = `${uploadDate.getFullYear()}-${uploadDate.getMonth()}-${uploadDate.getDay()}/${deliveryId}`; //formats path to YYYY-MM-DD/deliveryid
+    const bucketPath = `${uploadDate.getFullYear()}-${uploadDate.getMonth() + 1}-${uploadDate.getDate()}/${deliveryId}`; //formats path to YYYY-MM-DD/deliveryid
 
     const command = new PutObjectCommand({
       Bucket: process.env.BUCKET_NAME,

--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -267,7 +267,9 @@ function logPayloadToS3(body, deliveryId) {
   // If bucket name is not null (had to put this for the integration test)
   if (process.env.BUCKET_NAME) {
     const uploadDate = new Date();
-    const bucketPath = `${uploadDate.getFullYear()}-${uploadDate.getMonth() + 1}-${uploadDate.getDate()}/${deliveryId}`; //formats path to YYYY-MM-DD/deliveryid
+    const bucketPath = `${uploadDate.getFullYear()}
+          -${uploadDate.getMonth() + 1}
+          -${uploadDate.getDate()}/${deliveryId}`; //formats path to YYYY-MM-DD/deliveryid
 
     const command = new PutObjectCommand({
       Bucket: process.env.BUCKET_NAME,


### PR DESCRIPTION
**Description**
We noticed the events in the new github s3 bucket is creating folders with a wrong current date.

This was because the `getMonth` function is zero-index based so we have to add 1 to get the correct month.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5604

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
