### PR TITLE
SEAB-6405: Fix date/folder formatting for github app delivery bucket

### DIFF
--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -269,8 +269,8 @@ function logPayloadToS3(body, deliveryId) {
     const date = new Date();
     const uploadYear = date.getFullYear();
     const uploadMonth =
-      (date.getMonth() + 1).padStart(2, '0'); // ex. get 05 instead of 5 for May
-    const uploadDate = date.getDate().toString().padStart(2, '0'); // ex. get 05 instead of 5 for the 5th date
+      (date.getMonth() + 1).padStart(2, "0"); // ex. get 05 instead of 5 for May
+    const uploadDate = date.getDate().toString().padStart(2, "0"); // ex. get 05 instead of 5 for the 5th date
     const bucketPath = `${uploadYear}-${uploadMonth}-${uploadDate}/${deliveryId}`;
 
     const command = new PutObjectCommand({

--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -270,7 +270,7 @@ function logPayloadToS3(body, deliveryId) {
     const uploadYear = date.getFullYear();
     const uploadMonth = (date.getMonth() + 1 < 10 ? "0" : "") + (date.getMonth() + 1); // ex. get 05 instead of 5 for May
     const uploadDate = (date.getDate() < 10 ? "0" : "") + date.getDate(); // ex. get 05 instead of 5 for the 5th date
-    const bucketPath = `${uploadYear}-${uploadMonth}-${uploadDate.getDate()}/${deliveryId}`;
+    const bucketPath = `${uploadYear}-${uploadMonth}-${uploadDate}/${deliveryId}`;
 
     const command = new PutObjectCommand({
       Bucket: process.env.BUCKET_NAME,

--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -267,9 +267,9 @@ function logPayloadToS3(body, deliveryId) {
   // If bucket name is not null (had to put this for the integration test)
   if (process.env.BUCKET_NAME) {
     const uploadDate = new Date();
-    const bucketPath = `${uploadDate.getFullYear()}
-          -${uploadDate.getMonth() + 1}
-          -${uploadDate.getDate()}/${deliveryId}`; //formats path to YYYY-MM-DD/deliveryid
+    const bucketPath = `${uploadDate.getFullYear()}` +
+          `-${uploadDate.getMonth() + 1}` +
+          `-${uploadDate.getDate()}/${deliveryId}`; //formats path to YYYY-MM-DD/deliveryid
 
     const command = new PutObjectCommand({
       Bucket: process.env.BUCKET_NAME,

--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -268,7 +268,7 @@ function logPayloadToS3(body, deliveryId) {
   if (process.env.BUCKET_NAME) {
     const date = new Date();
     const uploadYear = date.getFullYear();
-    const uploadMonth = (date.getMonth() + 1).padStart(2, "0"); // ex. get 05 instead of 5 for May
+    const uploadMonth = (date.getMonth() + 1).toString().padStart(2, "0"); // ex. get 05 instead of 5 for May
     const uploadDate = date.getDate().toString().padStart(2, "0"); // ex. get 05 instead of 5 for the 5th date
     const bucketPath = `${uploadYear}-${uploadMonth}-${uploadDate}/${deliveryId}`;
 

--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -267,9 +267,10 @@ function logPayloadToS3(body, deliveryId) {
   // If bucket name is not null (had to put this for the integration test)
   if (process.env.BUCKET_NAME) {
     const uploadDate = new Date();
-    const bucketPath = `${uploadDate.getFullYear()}` +
-          `-${uploadDate.getMonth() + 1}` +
-          `-${uploadDate.getDate()}/${deliveryId}`; //formats path to YYYY-MM-DD/deliveryid
+    const bucketPath =
+        `${uploadDate.getFullYear()}` +
+        `-${uploadDate.getMonth() + 1}` +
+        `-${uploadDate.getDate()}/${deliveryId}`; //formats path to YYYY-MM-DD/deliveryid
 
     const command = new PutObjectCommand({
       Bucket: process.env.BUCKET_NAME,

--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -269,8 +269,8 @@ function logPayloadToS3(body, deliveryId) {
     const date = new Date();
     const uploadYear = date.getFullYear();
     const uploadMonth =
-      (date.getMonth() + 1 < 10 ? "0" : "") + (date.getMonth() + 1); // ex. get 05 instead of 5 for May
-    const uploadDate = (date.getDate() < 10 ? "0" : "") + date.getDate(); // ex. get 05 instead of 5 for the 5th date
+      (date.getMonth() + 1).padStart(2, '0'); // ex. get 05 instead of 5 for May
+    const uploadDate = date.getDate().toString().padStart(2, '0'); // ex. get 05 instead of 5 for the 5th date
     const bucketPath = `${uploadYear}-${uploadMonth}-${uploadDate}/${deliveryId}`;
 
     const command = new PutObjectCommand({

--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -268,8 +268,7 @@ function logPayloadToS3(body, deliveryId) {
   if (process.env.BUCKET_NAME) {
     const date = new Date();
     const uploadYear = date.getFullYear();
-    const uploadMonth =
-      (date.getMonth() + 1).padStart(2, "0"); // ex. get 05 instead of 5 for May
+    const uploadMonth = (date.getMonth() + 1).padStart(2, "0"); // ex. get 05 instead of 5 for May
     const uploadDate = date.getDate().toString().padStart(2, "0"); // ex. get 05 instead of 5 for the 5th date
     const bucketPath = `${uploadYear}-${uploadMonth}-${uploadDate}/${deliveryId}`;
 

--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -268,9 +268,9 @@ function logPayloadToS3(body, deliveryId) {
   if (process.env.BUCKET_NAME) {
     const uploadDate = new Date();
     const bucketPath =
-        `${uploadDate.getFullYear()}` +
-        `-${uploadDate.getMonth() + 1}` +
-        `-${uploadDate.getDate()}/${deliveryId}`; //formats path to YYYY-MM-DD/deliveryid
+      `${uploadDate.getFullYear()}` +
+      `-${uploadDate.getMonth() + 1}` +
+      `-${uploadDate.getDate()}/${deliveryId}`; //formats path to YYYY-MM-DD/deliveryid
 
     const command = new PutObjectCommand({
       Bucket: process.env.BUCKET_NAME,

--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -268,7 +268,8 @@ function logPayloadToS3(body, deliveryId) {
   if (process.env.BUCKET_NAME) {
     const date = new Date();
     const uploadYear = date.getFullYear();
-    const uploadMonth = (date.getMonth() + 1 < 10 ? "0" : "") + (date.getMonth() + 1); // ex. get 05 instead of 5 for May
+    const uploadMonth =
+      (date.getMonth() + 1 < 10 ? "0" : "") + (date.getMonth() + 1); // ex. get 05 instead of 5 for May
     const uploadDate = (date.getDate() < 10 ? "0" : "") + date.getDate(); // ex. get 05 instead of 5 for the 5th date
     const bucketPath = `${uploadYear}-${uploadMonth}-${uploadDate}/${deliveryId}`;
 

--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -268,12 +268,9 @@ function logPayloadToS3(body, deliveryId) {
   if (process.env.BUCKET_NAME) {
     const date = new Date();
     const uploadYear = date.getFullYear();
-    const uploadMonth =
-        (date.getMonth() + 1 < 10 ? "0" : "") + (date.getMonth() + 1); // ex. get 05 instead of 5 for May
-    const uploadDate =
-        (date.getDate() < 10 ? "0" : "") + date.getDate(); // ex. get 05 instead of 5 for the 5th date
-    const bucketPath =
-      `${uploadYear}-${uploadMonth}-${uploadDate.getDate()}/${deliveryId}`;
+    const uploadMonth = (date.getMonth() + 1 < 10 ? "0" : "") + (date.getMonth() + 1); // ex. get 05 instead of 5 for May
+    const uploadDate = (date.getDate() < 10 ? "0" : "") + date.getDate(); // ex. get 05 instead of 5 for the 5th date
+    const bucketPath = `${uploadYear}-${uploadMonth}-${uploadDate.getDate()}/${deliveryId}`;
 
     const command = new PutObjectCommand({
       Bucket: process.env.BUCKET_NAME,

--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -268,8 +268,10 @@ function logPayloadToS3(body, deliveryId) {
   if (process.env.BUCKET_NAME) {
     const date = new Date();
     const uploadYear = date.getFullYear();
-    const uploadMonth = (date.getMonth() + 1 < 10 ? '0' : '') + (date.getMonth() + 1);
-    const uploadDate = (date.getDate() < 10 ? '0' : '') + date.getDate();
+    const uploadMonth =
+        (date.getMonth() + 1 < 10 ? "0" : "") + (date.getMonth() + 1); // ex. get 05 instead of 5 for May
+    const uploadDate =
+        (date.getDate() < 10 ? "0" : "") + date.getDate(); // ex. get 05 instead of 5 for the 5th date
     const bucketPath =
       `${uploadYear}-${uploadMonth}-${uploadDate.getDate()}/${deliveryId}`;
 

--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -266,11 +266,12 @@ function processEvent(event, callback) {
 function logPayloadToS3(body, deliveryId) {
   // If bucket name is not null (had to put this for the integration test)
   if (process.env.BUCKET_NAME) {
-    const uploadDate = new Date();
+    const date = new Date();
+    const uploadYear = date.getFullYear();
+    const uploadMonth = (date.getMonth() + 1 < 10 ? '0' : '') + (date.getMonth() + 1);
+    const uploadDate = (date.getDate() < 10 ? '0' : '') + date.getDate();
     const bucketPath =
-      `${uploadDate.getFullYear()}` +
-      `-${uploadDate.getMonth() + 1}` +
-      `-${uploadDate.getDate()}/${deliveryId}`; //formats path to YYYY-MM-DD/deliveryid
+      `${uploadYear}-${uploadMonth}-${uploadDate.getDate()}/${deliveryId}`;
 
     const command = new PutObjectCommand({
       Bucket: process.env.BUCKET_NAME,


### PR DESCRIPTION
**Description**
The folder names were messed up in the new s3 github delivery bucket because of the linter formatting.

Before:
![image](https://github.com/dockstore/lambda/assets/61166764/b94469d5-99bc-4fce-adb6-654cc0bc4b4e)

After:
![image](https://github.com/dockstore/lambda/assets/61166764/76035a91-e095-4c2d-a6e4-425e8ac037fa)


**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6405

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [X] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
