### PR TITLE
SEAB-6452: add hour to bucket key for GitHub redelivery

### DIFF
--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -270,7 +270,8 @@ function logPayloadToS3(body, deliveryId) {
     const uploadYear = date.getFullYear();
     const uploadMonth = (date.getMonth() + 1).toString().padStart(2, "0"); // ex. get 05 instead of 5 for May
     const uploadDate = date.getDate().toString().padStart(2, "0"); // ex. get 05 instead of 5 for the 5th date
-    const bucketPath = `${uploadYear}-${uploadMonth}-${uploadDate}/${deliveryId}`;
+    const uploadHour = date.getHours().toString().padStart(2, "0"); // ex. get 05 instead of 5 for the 5th hour
+    const bucketPath = `${uploadYear}-${uploadMonth}-${uploadDate}/${uploadHour}/${deliveryId}`;
 
     const command = new PutObjectCommand({
       Bucket: process.env.BUCKET_NAME,


### PR DESCRIPTION
**Description**
This PR changes the bucket key format to `YYYY-MM-DD/HH/deliveryid` instead of `YYYY-MM-DD/deliveryid` such that we can resubmit events by the hour

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6452

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [X] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
