### PR TITLE
Change test to a different large file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,7 @@ commands:
           command: bash -i -c 'npm ci'
       - run:
           name: install individual lambda packages
-          command: bash -i -c 'npm --prefix checkUrlExists/lambda install'
+          command: bash -i -c 'npm --prefix checkUrlExists/lambda ci'
       - run:
           name: run unit tests
           command: bash -i -c 'npm run test'

--- a/checkUrlExists/lambda/tests/unit/test-handler.js
+++ b/checkUrlExists/lambda/tests/unit/test-handler.js
@@ -22,7 +22,7 @@ describe("Tests index", function () {
   });
   it("verifies successful response for large file", async () => {
     const url =
-      "https://dcc.icgc.org/api/v1/download?fn=/PCAWG/reference_data/data_for_testing/HCC1143_ds/HCC1143.bam";
+      "https://media.githubusercontent.com/media/bioinformatics-ca/bioinformatics-ca.github.io/master/data_sets/HCC1143.normal.21.19M-20M.bam";
     await setupTest(url, true);
   });
   it("verifies successful response from ftp file", async () => {


### PR DESCRIPTION
**Description**
A unit test started failing because the ICGC data portal was shut down.

Found a reasonably large file to replace the test with, although it's "only" 78M, compared to the previous file's 5.24GB.

The point of the test is to verify that a HEAD operation works, and while it's less than ideal, I think the file is big enough.

Also changed CircleCI build to use `npm ci` instead of `npm i`.

**Issue**
dockstore/dockstore#5935
DOCK-2548

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
