### PR TITLE
Send release events to web service

### DIFF
--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -120,6 +120,15 @@ function deleteEndpoint(
   req.end();
 }
 
+function handleReleaseEvent(githubEventType, body, deliveryId, path, callback) {
+  console.log("Valid release event");
+  const fullPath = path + "workflows/github/taggedrelease";
+  logPayloadToS3(githubEventType, body, deliveryId);
+  postEndpoint(fullPath, body, deliveryId, (response) => {
+    handleCallback(response, "", callback);
+  });
+}
+
 // Performs an action based on the event type (action)
 function processEvent(event, callback) {
   // Usually returns array of records, however it is fixed to only return 1 record
@@ -251,6 +260,8 @@ function processEvent(event, callback) {
         }
       );
     }
+  } else if (githubEventType === "release") {
+    handleReleaseEvent(githubEventType, body, deliveryId, path, callback);
   } else {
     console.log("Event " + githubEventType + " is not supported");
     callback(null, {

--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -260,7 +260,7 @@ function processEvent(event, callback) {
         }
       );
     }
-  } else if (githubEventType === "release") {
+  } else if (githubEventType === "released") {
     handleReleaseEvent(githubEventType, body, deliveryId, path, callback);
   } else {
     console.log("Event " + githubEventType + " is not supported");

--- a/upsertGitHubTag/deployment/index.js
+++ b/upsertGitHubTag/deployment/index.js
@@ -260,7 +260,7 @@ function processEvent(event, callback) {
         }
       );
     }
-  } else if (githubEventType === "released") {
+  } else if (githubEventType === "release") {
     handleReleaseEvent(githubEventType, body, deliveryId, path, callback);
   } else {
     console.log("Event " + githubEventType + " is not supported");


### PR DESCRIPTION
**Description**
Companion to dockstore/dockstore#5950. Sends release events to web service, also saves them to the github delivery bucket.

Tested manually. Will add programmatic tests to dockstore-deploy after this is merged (need to update submodule there).

**Issue**
SEAB-6466

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
