### PR TITLE
Display task container names for ECS task state change events

### DIFF
--- a/cloud-watch-to-slack-testing/deployment/index.js
+++ b/cloud-watch-to-slack-testing/deployment/index.js
@@ -258,7 +258,9 @@ function ecsTaskStateChangeMessageText(message) {
   const taskArn = message?.detail?.taskArn;
   const lastStatus = message?.detail?.lastStatus;
   let messageText = `Task ${taskArn} is now ${lastStatus}`;
-  const taskContainers = message?.detail?.containers?.map((container) => container.name).join(', ');
+  const taskContainers = message?.detail?.containers
+    ?.map((container) => container.name)
+    .join(", ");
   messageText += `\nTask containers: ${taskContainers}`;
   ["startedAt", "stoppedAt", "stoppedReason"].forEach((name) => {
     const value = message?.detail?.[name];

--- a/cloud-watch-to-slack-testing/deployment/index.js
+++ b/cloud-watch-to-slack-testing/deployment/index.js
@@ -261,7 +261,7 @@ function ecsTaskStateChangeMessageText(message) {
   const taskContainers = message?.detail?.containers
     ?.map((container) => container.name)
     .join(", ");
-  messageText += `\nTask containers: ${taskContainers}`;
+  messageText += `\nContainers: ${taskContainers}`;
   ["startedAt", "stoppedAt", "stoppedReason"].forEach((name) => {
     const value = message?.detail?.[name];
     if (value != undefined) {

--- a/cloud-watch-to-slack-testing/deployment/index.js
+++ b/cloud-watch-to-slack-testing/deployment/index.js
@@ -258,10 +258,13 @@ function ecsTaskStateChangeMessageText(message) {
   const taskArn = message?.detail?.taskArn;
   const lastStatus = message?.detail?.lastStatus;
   let messageText = `Task ${taskArn} is now ${lastStatus}`;
-  const taskContainers = message?.detail?.containers
-    ?.map((container) => container.name)
-    ?.join(", ");
-  messageText += `\nContainers: ${taskContainers}`;
+  const taskContainers = message?.detail?.containers;
+  if (Array.isArray(taskContainers)) {
+    const taskContainerNames = taskContainers
+      ?.map((container) => container.name)
+      ?.join(", ");
+    messageText += `\nContainers: ${taskContainerNames}`;
+  }
   ["startedAt", "stoppedAt", "stoppedReason"].forEach((name) => {
     const value = message?.detail?.[name];
     if (value != undefined) {

--- a/cloud-watch-to-slack-testing/deployment/index.js
+++ b/cloud-watch-to-slack-testing/deployment/index.js
@@ -258,6 +258,8 @@ function ecsTaskStateChangeMessageText(message) {
   const taskArn = message?.detail?.taskArn;
   const lastStatus = message?.detail?.lastStatus;
   let messageText = `Task ${taskArn} is now ${lastStatus}`;
+  const taskContainers = message?.detail?.containers?.map((container) => container.name).join(', ');
+  messageText += `\nTask containers: ${taskContainers}`;
   ["startedAt", "stoppedAt", "stoppedReason"].forEach((name) => {
     const value = message?.detail?.[name];
     if (value != undefined) {

--- a/cloud-watch-to-slack-testing/deployment/index.js
+++ b/cloud-watch-to-slack-testing/deployment/index.js
@@ -260,7 +260,7 @@ function ecsTaskStateChangeMessageText(message) {
   let messageText = `Task ${taskArn} is now ${lastStatus}`;
   const taskContainers = message?.detail?.containers
     ?.map((container) => container.name)
-    .join(", ");
+    ?.join(", ");
   messageText += `\nContainers: ${taskContainers}`;
   ["startedAt", "stoppedAt", "stoppedReason"].forEach((name) => {
     const value = message?.detail?.[name];


### PR DESCRIPTION
**Description**
This PR displays the containers that belong to the task when an ECS task state change event is received by the lambda.

See the dockstore-deploy PR https://github.com/dockstore/dockstore-deploy/pull/816 that redirects the events to different channels depending on if it's for the webservice task or a scheduled task.

The notifications now look like this for the webservice task:
```
Task arn:aws:ecs:us-east-2:<account-id>:task/KathysDockstore-DockstoreEcsCluster36A20B87-GI07lGcyBwKc/0d9fe1faba344695b0ad6fa00a3a5d0d is now STOPPED
Containers: bootstrap, webservice, cloudwatch-agent, migration, nginx
startedAt: 2024-12-10T18:04:28.393Z
stoppedAt: 2024-12-10T18:09:33.907Z
stoppedReason: Task stopped by user
```

and the topic updater task:
```
Task arn:aws:ecs:us-east-2:<account-id>:task/KathysDockstore-DockstoreEcsCluster36A20B87-GI07lGcyBwKc/e2509f7f865e4a00acb1866748c2431c is now STOPPED
Containers: TopicUpdater
startedAt: 2024-12-10T18:09:59.062Z
stoppedAt: 2024-12-10T18:10:32.301Z
stoppedReason: Essential container in task exited
```

**Issue**
Implemented while doing https://ucsc-cgl.atlassian.net/browse/SEAB-6795, but technically tackles https://ucsc-cgl.atlassian.net/browse/SEAB-6746

**Security**
If there are any concerns that require extra attention from the security team, highlight them here.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
